### PR TITLE
FIX: Link titles in TiLT have extra unnecessary spacing around

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,13 +24,8 @@ This is stable and basic feature complete, but being an actively run project thi
 
 ## Issues/Features
 
-### Sign up page
-_(Difficulty: **Easy**, Status: **Core done(Aalok)**)_  
-This is a blog letter, the sign-ups for the `letters` are handled through the form in the side bar (or on top in mobile view). Functionality-wise, it works fine, but it's still preferred to have a separate page for signup. With same form inputs. (So this eventually can be shared as a direct sign-up link on various social media platforms.)  
-
-P.S the sidebar should be present on the sign-up page too, we'll remove the sign-up form from the sidebar once a custom signup page is in place. Imagine this as a normal blog post, but instead of blog content, we have a signup form only. (use [this](https://perspectiveix.substack.com/) as a design sample)  
-
 ### [KD TiLT] Fix CSS to keep TiLT article titles closer
+_(Difficulty: **Easy**, Status: **Picked up(OhYash)**)_  
 Currently the title and it's information (Hashtags, read duration) are a bit far-apart. These have to be closer.
 (prefer not to use negative margin/padding).  
 Current sample:  
@@ -39,6 +34,12 @@ Current sample:
 ## Archived Issues.
 <details>
 	<summary>These items maybe done or cancelled.</summary>
+
+	### Sign up page
+	_(Difficulty: **Easy**, Status: **Done(Aalok)**)_  
+	This is a blog letter, the sign-ups for the `letters` are handled through the form in the side bar (or on top in mobile view). Functionality-wise, it works fine, but it's still preferred to have a separate page for signup. With same form inputs. (So this eventually can be shared as a direct sign-up link on various social media platforms.)  
+
+	P.S the sidebar should be present on the sign-up page too, we'll remove the sign-up form from the sidebar once a custom signup page is in place. Imagine this as a normal blog post, but instead of blog content, we have a signup form only. (use [this](https://perspectiveix.substack.com/) as a design sample)  
 
 	### Top bar above articles on home page
 	_(Difficulty: **Easy**, Status: **Done(Aalok)**)_  

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,13 +24,6 @@ This is stable and basic feature complete, but being an actively run project thi
 
 ## Issues/Features
 
-### [KD TiLT] Fix CSS to keep TiLT article titles closer
-_(Difficulty: **Easy**, Status: **Picked up(OhYash)**)_  
-Currently the title and it's information (Hashtags, read duration) are a bit far-apart. These have to be closer.
-(prefer not to use negative margin/padding).  
-Current sample:  
-![Gap near title in KD TiLT posts](assets/img/kd_tilt_title_gap.jpg)
-
 ## Archived Issues.
 <details>
 	<summary>These items maybe done or cancelled.</summary>
@@ -55,6 +48,14 @@ Current sample:
 	Search functionality for the website. There are libraries to do that [[1](https://github.com/christian-fei/Simple-Jekyll-Search)],[[2](https://www.alaycock.co.uk/2016/02/setting-up-lunr-js-in-jekyll)], more?  
 
 	This is not yet tested and implementation is away. Would love it if you can share hands for this. Another thing that can be explored with this is using "[search with google](https://talk.jekyllrb.com/t/how-to-add-a-search-bar/606/3)" in Jekyll blogs if native searches are not good enough.  
+
+	### [KD TiLT] Fix CSS to keep TiLT article titles closer
+	_(Difficulty: **Easy**, Status: **Done(OhYash)**)_  
+	Currently the title and it's information (Hashtags, read duration) are a bit far-apart. These have to be closer.
+	(prefer not to use negative margin/padding).  
+	Current sample:  
+	![Gap near title in KD TiLT posts](assets/img/kd_tilt_title_gap.jpg)
+
 </details>
 
 ### Something else?

--- a/_posts/2021-07-15-mind-your-qs.md
+++ b/_posts/2021-07-15-mind-your-qs.md
@@ -61,7 +61,7 @@ Improvise. Adapt. Overcome.
 
 An Adaptability Quotient (AQ) measures someone's ability to adapt. This ability to adapt might include how people handle change, learn from mistakes, overcome challenges, and adjust in real-time.  
 Effectively the metric to measure your adaptiveness to the only constant there is - Change.  
-‍
+
 ------
 
 Welp, that's all for this issue. 5 metrics to measure yourself, should you be interested in knowing and exploring more (Hint: tickling your CQ), you can check out the sources below from where I gathered all this information for you.  

--- a/_posts/2021-08-25-tilt-four.md
+++ b/_posts/2021-08-25-tilt-four.md
@@ -2,7 +2,7 @@
 published: true
 layout: post
 date: '2021-09-24 15:00:00 +0530'
-title: KD TiLT 4 - The future of finance actually is looking really interesting
+title: KD TiLT 4 - The future of finance is looking really interesting
 img: kd_tilt.png
 fig-caption: KD TiLT
 tags:
@@ -38,7 +38,7 @@ Alrighty, let's look at the projects now...
 -----
 
 _#video: Generations of blockchains_
-### Cardano - Simply Explained
+### [Cardano - Simply Explained](https://cutt.ly/dWRrtFh)
 _8 minutes | Youtube/Simply Explained_
 
 [![Cardano video](http://i3.ytimg.com/vi/Do8rHvr65ZA/hqdefault.jpg)](https://cutt.ly/dWRrtFh)
@@ -51,7 +51,7 @@ But how does Cardano, which claims to be the third generation blockchain work an
 --------
 
 _#gaming_
-### Gaming with real digital transactions
+### [Gaming with real digital transactions](https://cutt.ly/wWRe8cR)
 _Upland_
 
 ![Upland hero](https://static.news.bitcoin.com/wp-content/uploads/2021/02/l0MZG6do-upland.png)  
@@ -70,7 +70,7 @@ Few more games on blockchain: [Sandbox](https://www.sandbox.game/en/about/sand/)
 --------
 
 _#file share_
-### Cloud, people powered - File Coin
+### [Cloud, people powered - File Coin](https://cutt.ly/xWReBCh)
 _7 - 9 minutes read | decrypt_
 
 Know about Richard's idea for new internet (from the Silicon Valley TV show)? If you do, then you know this is the only way it could be executed.  
@@ -83,7 +83,7 @@ Filecoin is a decentralized storage provider and covers up for the storage part 
 --------
 
 _#card_
-### Real hardware wallet
+### [Real hardware wallet](https://cutt.ly/hWReVJY)
 _safepal_
 
 ![Safepal video as gif or image](https://c.tenor.com/kdGPgfgC3xgAAAAd/safepal-safepal-wallet.gif)  
@@ -96,7 +96,7 @@ The PayPal of cryptocurrencies. This gives you a real card for transactions. Did
 ------
 
 _#content_
-### Hive - The content creator's blockchain
+### [Hive - The content creator's blockchain](https://cutt.ly/GWReCO2)
 _Hive Ecosystem_
 
 In 2016, a blockchain-based blogging and social media website called **Steemit** started catching eyes. Why? Because of its blogging platform. It's a combination of Reddit and Medium functionality-wise and allowed a very easy way of earning through your content.  

--- a/_posts/2021-09-25-tilt-five.md
+++ b/_posts/2021-09-25-tilt-five.md
@@ -38,7 +38,7 @@ _Meet Keto, a 1.5YO grumpy Persian cat_
 -----
 
 _#fitness_
-### How to Run Slower to Run Faster
+### [How to Run Slower to Run Faster](https://lifehacker.com/how-to-run-slower-to-run-faster-1847752652?utm_source=knowledgeday_newsletter)
 _4 - 5 minutes | Life Hacker_
 
 ![walk/run](https://i.kinja-img.com/gawker-media/image/upload/c_fit,f_auto,g_center,pg_1,q_60,w_965/569fcc167e8acfc8927f212aa83a975e.jpg)  
@@ -52,7 +52,7 @@ Care to read how it works?
 --------
 
 _#petting_
-### These lockdown owners are full of pet regrets
+### [These lockdown owners are full of pet regrets](https://getpocket.com/explore/item/yappy-dogs-moody-cats-why-lockdown-owners-are-full-of-pet-regret?utm_source=knowledgeday_newsletter)
 _5 - 6 minutes read | The Guardian_
 
 ![Unhappy dog](https://pocket-syndicated-images.s3.amazonaws.com/61413544bd467.jpg)  
@@ -66,7 +66,7 @@ Did I tell you how often do they defecate in a day? This article covers that alo
 --------
 
 _#tech_
-### Sieve that... email?
+### [Sieve that... email?](http://sieve.info/overview?utm_source=knowledgeday_newsletter)
 _5 - 6 minutes read | sieve.info_
 
 Draft by Tim Showadlter, Sieve is a proposed internet standard language to filter emails. Y'know, the email filter you use to separate off your Slack and maybe Jira emails from the main inbox.  
@@ -77,7 +77,7 @@ I didn't know that syntax has a name too. Did you?
 --------
 
 _#Space_
-### James Webb telescope is going to be 100 times as powerful as the popular Hubble telescope
+### [James Webb telescope is going to be 100 times as powerful as the popular Hubble telescope](https://www.vox.com/science-and-health/22664709/james-webb-space-telescope-launch-date-december-science-hubble?utm_source=knowledgeday_newsletter)
 _16 - 20 minutes | Vox_
 
 ![james webb telescope](https://cdn.vox-cdn.com/thumbor/YXEO1ytzTrrFO6kWowWkr08B0nM=/0x0:1414x957/920x0/filters:focal(0x0:1414x957):format(webp):no_upscale()/cdn.vox-cdn.com/uploads/chorus_asset/file/22863755/JWST_HST_primary_mirrors.jpeg)
@@ -91,7 +91,7 @@ Wanna see how else can they be contrasted, and see some unforgettable, jaw-dropp
 ------
 
 _#video_
-### Is Success Luck or Hard Work?
+### [Is Success Luck or Hard Work?](https://www.youtube.com/watch?v=3LopI4YeC4I?utm_source=knowledgeday_newsletter)
 _12 minutes | Youtube/Veritasium_
 
 [![Success paradox](https://i3.ytimg.com/vi/3LopI4YeC4I/hqdefault.jpg)](https://www.youtube.com/watch?v=3LopI4YeC4I?utm_source=knowledgeday_newsletter)

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1253,7 +1253,7 @@ a.newer-posts:hover {
   margin-top: 0px;
 }
 
-.wrap-content h3 + p em:only-child {
+.wrap-content hr + p + h3 + p em:only-child {
   color: slategray;
 }
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1232,6 +1232,31 @@ a.newer-posts:hover {
   margin-bottom: 5%;
 }
 
+.wrap-content hr + p {
+  margin-bottom: 0px;
+}
+
+.wrap-content hr + p em:only-child {
+  color: darkgray;
+}
+
+.wrap-content hr + p + h3 {
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.wrap-content hr + p + h3 a:only-child {
+  color: #515151;
+}
+
+.wrap-content h3 + p {
+  margin-top: 0px;
+}
+
+.wrap-content h3 + p em:only-child {
+  color: slategray;
+}
+
 .header-page {
   text-align: center;
   margin: 10px 0;


### PR DESCRIPTION
Fixing one item from the CONTRIBUTING.md:
Currently the title and it's information (Hashtags, read duration) are a bit far-apart. These have to be closer.
(prefer not to use negative margin/padding).  
Current sample:  
![Gap near title in KD TiLT posts](assets/img/kd_tilt_title_gap.jpg)